### PR TITLE
Arc labeling

### DIFF
--- a/styles/RolePlayGateway/template/roleplay_stream_body.html
+++ b/styles/RolePlayGateway/template/roleplay_stream_body.html
@@ -43,10 +43,10 @@
 						    document.taggedCharacters[{activity.ID}] = [];
 						  </script>
 
-							<a href="#" style="display:block; clear:both;" class="button bundleButton" data-for="{activity.ID}">Add to Bundle &raquo;</a>
+							<a href="#" style="display:block; clear:both;" class="button bundleButton" data-for="{activity.ID}">Add to Arc &raquo;</a>
 							<div class="bundleListWrapper" style="display:none;" data-for="{activity.ID}">
 								<div class="bundleList" data-for="{activity.ID}"></div>
-								<a href="/ucp.php?i=roleplays&mode=add_arc&roleplay_id={ID}&with_post={activity.ID}" class="button" style="float: right; clear: both; font-size: 1.2em;">new bundle &raquo;</a>
+								<a href="/ucp.php?i=roleplays&mode=add_arc&roleplay_id={ID}&with_post={activity.ID}" class="button" style="float: right; clear: both; font-size: 1.2em;">new arc &raquo;</a>
 							</div>
 						</div>
 						<div style="clear: both;">


### PR DESCRIPTION
Add to bundle button fails to communicate anything about its relevance
to arcs to users. Renamed the displayed strings.